### PR TITLE
Rename Modal component to Dialog

### DIFF
--- a/css/hugo/content/components/dialog.md
+++ b/css/hugo/content/components/dialog.md
@@ -1,27 +1,27 @@
 ---
-title: Modals
-description: Show modals to users.
+title: Dialogs
+description: Show dialogs to users.
 section: components
 ---
 
 ## Example
-Mellow's modal uses the `dialog` element, this native HTML element is supported in all modern browsers.
+Mellow's dialog uses the `dialog` element, this native HTML element is supported in all modern browsers.
 
 {{<example>}}
-<dialog class="modal" id="exampleDialog">
-  <form method="dialog" class="modal-header">
-    <h3 class="h5">This is a modal</h3>
+<dialog class="dialog" id="exampleDialog">
+  <form method="dialog" class="dialog-header">
+    <h3 class="h5">This is a dialog</h3>
     <button value="cancel" class="btn-close"><i class="vi vi-xmark"></i></button>
   </form>
-  <div class="modal-body">
+  <div class="dialog-body">
     <p>Hello world!</p>
-    <p>This modal can be closed with the <kb>esc</kb> button.</p>
+    <p>This dialog can be closed with the <kb>esc</kb> button.</p>
   </div>
-  <form method="dialog" class="modal-footer">
+  <form method="dialog" class="dialog-footer">
     <button value="cancel" class="btn btn-danger"><i class="vi vi-xmark"></i> Close</button>
   </form>
 </dialog>
-<button class="btn btn-default" onclick="window.exampleDialog.showModal();">Open modal</button>
+<button class="btn btn-default" onclick="window.exampleDialog.showModal();">Open dialog</button>
 {{</example>}}
 
 ### `show()` and `showModal()`
@@ -30,14 +30,14 @@ There are 2 methods to open a model: `show()` and `showModal()`. We'll refer to 
 The `showModal()` method does everything the `show()` method does, but also respects the `autofocus` property, and makes sure the dialog is displayed on top of the stack.
 
 {{<example>}}
-<dialog class="modal" id="showDialog">
-  <form method="dialog" class="modal-header">
-    <h3 class="h5">This is a modal</h3>
+<dialog class="dialog" id="showDialog">
+  <form method="dialog" class="dialog-header">
+    <h3 class="h5">This is a dialog</h3>
     <button value="cancel" class="btn-close"><i class="vi vi-xmark"></i></button>
   </form>
-  <div class="modal-body">
+  <div class="dialog-body">
     <p>Hello world!</p>
-    <p>This modal can be closed with the <kb>esc</kb> button.</p>
+    <p>This dialog can be closed with the <kb>esc</kb> button.</p>
   </div>
 </dialog>
 <button class="btn btn-default" onclick="window.showDialog.showModal();">Use show()</button>
@@ -50,32 +50,32 @@ The `showModal()` method does everything the `show()` method does, but also resp
 <button class="btn btn-default" onclick="window.largeDialog.showModal();">Open Large</button>
 <button class="btn btn-default" onclick="window.extraLargeDialog.showModal();">Open Extra Large</button>
 
-<dialog class="modal modal-sm" id="smallDialog">
-  <form method="dialog" class="modal-header">
-    <h3 class="h5">This is a modal</h3>
+<dialog class="dialog dialog-sm" id="smallDialog">
+  <form method="dialog" class="dialog-header">
+    <h3 class="h5">This is a dialog</h3>
     <button value="cancel" class="btn-close"><i class="vi vi-xmark"></i></button>
   </form>
-  <div class="modal-body">
-    <p>Tiny modal says "hi".</p>
+  <div class="dialog-body">
+    <p>Tiny dialog says "hi".</p>
   </div>
 </dialog>
 
-<dialog class="modal modal-lg" id="largeDialog">
-  <form method="dialog" class="modal-header">
-    <h3 class="h5">This is a modal</h3>
+<dialog class="dialog dialog-lg" id="largeDialog">
+  <form method="dialog" class="dialog-header">
+    <h3 class="h5">This is a dialog</h3>
     <button value="cancel" class="btn-close"><i class="vi vi-xmark"></i></button>
   </form>
-  <div class="modal-body">
+  <div class="dialog-body">
     <p>This is big.</p>
   </div>
 </dialog>
 
-<dialog class="modal modal-xl" id="extraLargeDialog">
-  <form method="dialog" class="modal-header">
-    <h3 class="h5">This is a modal</h3>
+<dialog class="dialog dialog-xl" id="extraLargeDialog">
+  <form method="dialog" class="dialog-header">
+    <h3 class="h5">This is a dialog</h3>
     <button value="cancel" class="btn-close"><i class="vi vi-xmark"></i></button>
   </form>
-  <div class="modal-body">
+  <div class="dialog-body">
     <p>There is so much space in here! (echo)</p>
   </div>
 </dialog>

--- a/css/hugo/data/docs.yml
+++ b/css/hugo/data/docs.yml
@@ -22,11 +22,11 @@
     - title: Button
     - title: Button group
     - title: Card
+    - title: Dialog
     - title: Dropdown
     - title: Form
     - title: Label
     - title: List
-    - title: Modal
     - title: Nav
     - title: Offcanvas
     - title: Pagination

--- a/css/scss/_dialog.scss
+++ b/css/scss/_dialog.scss
@@ -1,4 +1,4 @@
-.modal {
+.dialog {
   color: inherit;
   padding: 0;
   border: none;
@@ -6,7 +6,7 @@
   background-color: var(--acrylic-solid-background);
   box-shadow: map-get($box-shadows, 1), map-get($box-shadows, 3);
   width: 100%;
-  max-width: $modal-md;
+  max-width: $dialog-md;
 
   @supports (backdrop-filter: blur(15px) saturate(350%)) {
     background-color: var(--acrylic-background);
@@ -21,20 +21,20 @@
     }
   }
 
-  &.modal-sm {
-    max-width: $modal-sm;
+  &.dialog-sm {
+    max-width: $dialog-sm;
   }
 
-  &.modal-lg {
-    max-width: $modal-lg;
+  &.dialog-lg {
+    max-width: $dialog-lg;
   }
 
-  &.modal-xl {
-    max-width: $modal-xl;
+  &.dialog-xl {
+    max-width: $dialog-xl;
   }
 }
 
-.modal-header {
+.dialog-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -46,7 +46,7 @@
   }
 }
 
-.modal-body {
+.dialog-body {
   padding: $spacer * .75;
 
   :last-child {
@@ -54,7 +54,7 @@
   }
 }
 
-.modal-footer {
+.dialog-footer {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/css/scss/_variable.scss
+++ b/css/scss/_variable.scss
@@ -401,8 +401,8 @@ $progress-heights: (
   lg: 1rem,
 ) !default;
 
-// Modals
-$modal-sm:        400px !default;
-$modal-md:        600px !default;
-$modal-lg:        800px !default;
-$modal-xl:        1200px !default;
+// Dialogs
+$dialog-sm:        400px !default;
+$dialog-md:        600px !default;
+$dialog-lg:        800px !default;
+$dialog-xl:        1200px !default;

--- a/css/scss/mellow.scss
+++ b/css/scss/mellow.scss
@@ -31,7 +31,7 @@
 @import "forms";
 @import "labels";
 @import "list";
-@import "modal";
+@import "dialog";
 @import "nav";
 @import "offcanvas";
 @import "pagination";


### PR DESCRIPTION
This pull request implements a small terminology fix. A modal is any UI that changes the user experience. By definition, a dropdown is also a modal. Dialog is the correct term to use in this instance.