### PR TITLE
Mellow CSS 0.3

### DIFF
--- a/hugo/content/layout/grid.md
+++ b/hugo/content/layout/grid.md
@@ -37,10 +37,10 @@ By using the `grid-*` classes, you can tell the grid layout to change the number
 {{</example>}}
 
 ### Custom grid counts
-While the grid classes are limited to 12, you can create grids with as much columns as you'd like by simply setting the `--grid-columns` variable.
+While the grid classes are limited to 12, you can create grids with as much columns as you'd like by simply setting the `--columns` variable.
 
 {{<example class="docs-preview-grid">}}
-<div class="grid" style="--grid-columns: 13">
+<div class="grid" style="--columns: 13">
   <div>1/13</div>
   <div>1/13</div>
   <div>1/13</div>
@@ -61,7 +61,7 @@ If you prefer classes, this will help you make additional classes without the ne
 
 {{<example class="docs-preview-grid" show_preview="false" lang="scss">}}
 .grid-13 {
-  --grid-columns: 13;
+  --columns: 13;
 }
 {{</example>}}
 

--- a/hugo/content/layout/grid.md
+++ b/hugo/content/layout/grid.md
@@ -36,6 +36,44 @@ By using the `grid-*` classes, you can tell the grid layout to change the number
 </div>
 {{</example>}}
 
+### Custom grid counts
+While the grid classes are limited to 12, you can create grids with as much columns as you'd like by simply setting the `--grid-columns` variable.
+
+{{<example class="docs-preview-grid">}}
+<div class="grid" style="--grid-columns: 13">
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+  <div>1/13</div>
+</div>
+{{</example>}}
+
+If you prefer classes, this will help you make additional classes without the need of deeper knowledge for how the grid is being defined.
+
+{{<example class="docs-preview-grid" show_preview="false" lang="scss">}}
+.grid-13 {
+  --grid-columns: 13;
+}
+{{</example>}}
+
+Alternatively, you can also change the SCSS variables to make Mellow generate the full suit of classes. The grid columns and utilities can be configured separately from each other but the utility classes will follow the number of columns by default.
+
+{{<example class="docs-preview-grid" show_preview="false" lang="scss">}}
+$grid-columns: 13 !default;
+$grid-utility-columns: $grid-columns !default;
+{{</example>}}
+
+This will generate the `grid-[breakpoint]-13` classes (controlled by the `$grid-columns` variable), as well as the `col-[breakpoint]-13` and `col-start-[breakpoint]-13` (controlled by the `$grid-utility-columns` variable).
+
 ### Responsive classes
 Mellow also provides support for changing the number of columns based on the viewport with with breakpoings.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,7 +1,9 @@
 .grid {
+  --grid-columns: 1;
+
   display: grid;
   grid-template-rows: repeat(1, 1fr);
-  grid-template-columns: repeat(1, 1fr);
+  grid-template-columns: repeat(var(--grid-columns), 1fr);
   gap: $spacer;
   width: 100%;
 }
@@ -10,10 +12,9 @@
   $breakpoint-suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
   @include breakpoint-min-width($breakpoint, $grid-breakpoints) {
-    // End at 11 because 12 would just result in the default column count
-    @for $i from 2 through 12 {
+    @for $i from 2 through $grid-columns {
       .grid#{$breakpoint-suffix}-#{$i} {
-        grid-template-columns: repeat($i, minmax(0, 1fr));
+        --grid-columns: #{ $i };
       }
     }
   }
@@ -23,7 +24,7 @@
   $breakpoint-suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
   @include breakpoint-min-width($breakpoint, $grid-breakpoints) {
-    @for $i from 1 through 12 {
+    @for $i from 1 through $grid-utility-columns {
       .col#{$breakpoint-suffix}-#{$i} {
         grid-column: auto/ span $i;
       }
@@ -33,7 +34,7 @@
       grid-column: 1 / -1;
     }
 
-    @for $i from 1 through 12 {
+    @for $i from 1 through $grid-utility-columns {
       .col-start#{$breakpoint-suffix}-#{$i} {
         grid-column-start: $i;
       }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,9 +1,7 @@
 .grid {
-  --grid-columns: 1;
-
   display: grid;
   grid-template-rows: repeat(1, 1fr);
-  grid-template-columns: repeat(var(--grid-columns), 1fr);
+  grid-template-columns: repeat(var(--columns, 1), 1fr);
   gap: $spacer;
   width: 100%;
 }
@@ -14,7 +12,7 @@
   @include breakpoint-min-width($breakpoint, $grid-breakpoints) {
     @for $i from 2 through $grid-columns {
       .grid#{$breakpoint-suffix}-#{$i} {
-        --grid-columns: #{ $i };
+        --columns: #{ $i };
       }
     }
   }

--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -10,7 +10,7 @@
   $breakpoint-suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
   @include breakpoint-min-width($breakpoint, $grid-breakpoints) {
-    @for $i from 2 through $grid-columns {
+    @for $i from 1 through $grid-columns {
       .grid#{$breakpoint-suffix}-#{$i} {
         --columns: #{ $i };
       }

--- a/scss/_variable.scss
+++ b/scss/_variable.scss
@@ -57,8 +57,8 @@ $anchor-color:          shade($accent, 7%) !default;
 $anchor-hover-color:    shade($accent, 22%) !default;
 
 // Grid breakpoints
-$grid-columns: 12;
-$grid-utility-columns: $grid-columns;
+$grid-columns: 12 !default;
+$grid-utility-columns: $grid-columns !default;
 $grid-breakpoints: (
   xs: 0,
   sm: 600px,

--- a/scss/_variable.scss
+++ b/scss/_variable.scss
@@ -370,7 +370,7 @@ $overflows: (
 ) !default;
 
 // Buttons
-$btn-box-shadow-inset: light-dark(inset 0 1px 0 rgba(255, 255, 255, .15), initial) !default;
+$btn-box-shadow-inset: var(--shadow-inset-btn) !default;
 
 $btn-semantic-color-hover: (
   secondary: "accent",
@@ -383,7 +383,7 @@ $btn-semantic-color: (
 ) !default;
 
 // Forms
-$form-box-shadow-inset: inset 0 1px 0 rgba(0, 0, 0, .075) !default;
+$form-box-shadow-inset: var(--shadow-inset-input) !default;
 
 // Transitions
 $fast-transition: all .1s ease-in-out;

--- a/scss/_variable.scss
+++ b/scss/_variable.scss
@@ -57,6 +57,8 @@ $anchor-color:          shade($accent, 7%) !default;
 $anchor-hover-color:    shade($accent, 22%) !default;
 
 // Grid breakpoints
+$grid-columns: 12;
+$grid-utility-columns: $grid-columns;
 $grid-breakpoints: (
   xs: 0,
   sm: 600px,

--- a/scss/_variable.scss
+++ b/scss/_variable.scss
@@ -163,11 +163,11 @@ $rfs-max-vw:      1100 !default;
 
 // Shadows
 $box-shadows: (
-  1: (.1px .1px .5px rgba(0, 0, 0, .032), .4px .4px 1.8px rgba(0, 0, 0, .048), 2px 2px 8px rgba(0, 0, 0, .08)),
-  2: (.1px .1px .7px rgba(0, 0, 0, .04), .4px .4px 2.2px rgba(0, 0, 0, .06), 2px 2px 10px rgba(0, 0, 0, .1)),
-  3: (.1px .1px .9px rgba(0, 0, 0, .048), .4px .4px 3.1px rgba(0, 0, 0, .072), 2px 2px 14px rgba(0, 0, 0, .12)),
-  4: (.2px .2px 1.2px rgba(0, 0, 0, .057), .7px .7px 4px rgba(0, 0, 0, .083), 3px 3px 18px rgba(0, 0, 0, .14)),
-  5: (.2px .2px 1.5px rgba(0, 0, 0, .069), .7px .7px 4.9px rgba(0, 0, 0, .101), 3px 3px 22px rgba(0, 0, 0, .17))
+  1: var(--shadow-1),
+  2: var(--shadow-2),
+  3: var(--shadow-3),
+  4: var(--shadow-4),
+  5: var(--shadow-5)
 ) !default;
 
 // Borders

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -8,6 +8,8 @@
   --shadow-3: .1px .1px .9px rgba(0, 0, 0, .048), .4px .4px 3.1px rgba(0, 0, 0, .072), 2px 2px 14px rgba(0, 0, 0, .12);
   --shadow-4: .2px .2px 1.2px rgba(0, 0, 0, .057), .7px .7px 4px rgba(0, 0, 0, .083), 3px 3px 18px rgba(0, 0, 0, .14);
   --shadow-5: .2px .2px 1.5px rgba(0, 0, 0, .069), .7px .7px 4.9px rgba(0, 0, 0, .101), 3px 3px 22px rgba(0, 0, 0, .17);
+  --shadow-inset-btn: #{ light-dark(inset 0 1px 0 rgba(255, 255, 255, .15), initial) };
+  --shadow-inset-input: inset 0 1px 0 rgba(0, 0, 0, .075);
 }
 
 // Dark mode

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -1,6 +1,15 @@
 /* stylelint-disable declaration-colon-space-after */
 /* stylelint-disable declaration-block-semicolon-space-before */
 
+// Root
+:root {
+  --shadow-1: .1px .1px .5px rgba(0, 0, 0, .032), .4px .4px 1.8px rgba(0, 0, 0, .048), 2px 2px 8px rgba(0, 0, 0, .08);
+  --shadow-2: .1px .1px .7px rgba(0, 0, 0, .04), .4px .4px 2.2px rgba(0, 0, 0, .06), 2px 2px 10px rgba(0, 0, 0, .1);
+  --shadow-3: .1px .1px .9px rgba(0, 0, 0, .048), .4px .4px 3.1px rgba(0, 0, 0, .072), 2px 2px 14px rgba(0, 0, 0, .12);
+  --shadow-4: .2px .2px 1.2px rgba(0, 0, 0, .057), .7px .7px 4px rgba(0, 0, 0, .083), 3px 3px 18px rgba(0, 0, 0, .14);
+  --shadow-5: .2px .2px 1.5px rgba(0, 0, 0, .069), .7px .7px 4.9px rgba(0, 0, 0, .101), 3px 3px 22px rgba(0, 0, 0, .17);
+}
+
 // Dark mode
 .system,
 .light {


### PR DESCRIPTION
Mellow CSS 0.3 is a minor feature update.

## New features
- c1853b9 Update grid system to support custom grid column counts through variables.
- bd5def8 Adds the `grid-[beakpoint]-1` classes.
- 2610280 Shadows are now primarily defined as CSS variables.

## Fixes
- cabbdcf Fixes some SCSS compilers identifying the key names in `$colors` as colors.