### PR TITLE
Mellow CSS 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_cards.scss
+++ b/scss/_cards.scss
@@ -1,4 +1,5 @@
 .card {
+  all: unset;
   position: relative;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Mellow CSS 0.3.2 is a minor update to address a missing feature for cards.

## Changes
- Supports `card` as buttons.