### PR TITLE
Mellow CSS 0.4.1

### DIFF
--- a/hugo/content/components/breadcrumb.md
+++ b/hugo/content/components/breadcrumb.md
@@ -15,6 +15,14 @@ Breadcrumbs are a simple component to show a visual hiarchy within your site.
 </nav>
 {{</example>}}
 
+{{<example>}}
+<nav aria-label="breadcrumb" class="breadcrumb">
+  <span class="breadcrumb-item"><button>Home</button></span>
+  <span class="breadcrumb-item"><button>Categories</button></span>
+  <span class="breadcrumb-item active" aria-current="page"><span>Tags</span></span>
+</nav>
+{{</example>}}
+
 ## Colors
 Like other components, the breadcrumb will follow your accent color or a custom color you can specify.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_breadcrumb.scss
+++ b/scss/_breadcrumb.scss
@@ -9,7 +9,10 @@
 }
 
 .breadcrumb-item {
-  & > a {
+  & > a,
+  & > button {
+    all: unset;
+    display: inline-block;
     color: var(--color-600, var(--accent-600));
     text-decoration: none;
     padding: $spacer * .25 $spacer * .375;
@@ -22,6 +25,7 @@
   }
 
   & > span {
+    display: inline-block;
     padding: $spacer * .25 $spacer * .375;
   }
 


### PR DESCRIPTION
Mellow CSS 0.4.1 fixes one issue with breadcrumbs.

## Fixed issues
- Fixes missing support for buttons in breadcrumbs.