### PR TITLE
Mellow CSS 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "copyfiles": "2.4.1",
         "eslint": "8.17.0",
         "find-unused-sass-variables": "4.0.4",
-        "hugo-bin": "0.88.2",
+        "hugo-bin": "0.89.0",
         "nodemon": "2.0.16",
         "npm-run-all": "4.1.5",
         "postcss": "8.4.14",
@@ -4917,9 +4917,9 @@
       "dev": true
     },
     "node_modules/hugo-bin": {
-      "version": "0.88.2",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.88.2.tgz",
-      "integrity": "sha512-MdSczDJqVh75w0ERXLuU72ACQ+IlS5AROoh1gecdagZxoLF3Wj50gVOZRoBcx5qFaGkEDcdw2a1YQeEEUsZVKw==",
+      "version": "0.89.0",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.89.0.tgz",
+      "integrity": "sha512-vJFD0UjVP0XOhy6YqTSRe9sRUWxFsrJnJZgTMTJUEXz5ks8apncY2F9h32srQy9wRRrlRgXVD8iBS9nztb5VbA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -12537,9 +12537,9 @@
       "dev": true
     },
     "hugo-bin": {
-      "version": "0.88.2",
-      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.88.2.tgz",
-      "integrity": "sha512-MdSczDJqVh75w0ERXLuU72ACQ+IlS5AROoh1gecdagZxoLF3Wj50gVOZRoBcx5qFaGkEDcdw2a1YQeEEUsZVKw==",
+      "version": "0.89.0",
+      "resolved": "https://registry.npmjs.org/hugo-bin/-/hugo-bin-0.89.0.tgz",
+      "integrity": "sha512-vJFD0UjVP0XOhy6YqTSRe9sRUWxFsrJnJZgTMTJUEXz5ks8apncY2F9h32srQy9wRRrlRgXVD8iBS9nztb5VbA==",
       "dev": true,
       "requires": {
         "bin-wrapper": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "copyfiles": "2.4.1",
     "eslint": "8.17.0",
     "find-unused-sass-variables": "4.0.4",
-    "hugo-bin": "0.88.2",
+    "hugo-bin": "0.89.0",
     "nodemon": "2.0.16",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -10,6 +10,10 @@
   color: var(--form-text);
   transition: $base-transition;
 
+  &::placeholder {
+    color: $muted;
+  }
+
   &:focus {
     outline: 0;
     border-color: var(--color-600, var(--accent-600));
@@ -327,14 +331,18 @@ select.input {
   align-items: center;
   justify-content: space-between;
   border-radius: $border-radius;
-  padding: 0 15px;
+  padding: 0 $spacer * .75;
   font-size: 1rem;
   line-height: 1;
   height: 36px;
-  background-color: #fff;
+  background-color: var(--form-background);
   color: var(--form-text);
   border: $border-color 1px solid;
   width: 100%;
+
+  .placeholder {
+    color: $muted;
+  }
 
   &:focus {
     outline: 0;
@@ -357,4 +365,21 @@ select.input {
       height: 16px;
     }
   }
+}
+
+.listbox {
+  position: absolute;
+  top: 100%;
+  right: auto;
+  bottom: auto;
+  left: 0;
+  overflow: auto;
+  width: 100%;
+  border-radius: $border-radius;
+  background-color: var(--form-background);
+  padding: $spacer * .25;
+  margin-top: $spacer * .25;
+  box-shadow: var(--shadow-2);
+  list-style: none;
+  z-index: 100;
 }


### PR DESCRIPTION
Mellow CSS v0.6.1 adds missing styling for `input-select` and broken behavior when using a dark theme.

## Changes
- [x] 047167a Mellow CSS now includes styling for the `::placeholder` pseudo-element and for the `placeholder` class.

## Fixes
- [x] 047167a Fixes the background color being hardcoded for the select with `input-select`
  - Adds a `listbox` class to combine CSS atoms for the Mellow UI select component.
  - Fixes missing z-index for the `listbox`.