### PR TITLE
Mellow CSS 0.11

### DIFF
--- a/hugo/content/components/alert.md
+++ b/hugo/content/components/alert.md
@@ -75,7 +75,7 @@ As a result of the use of CSS variable to style the colors, any element that res
   <div class="alert-message">
     <p>Look at this alert message! <a href="#">Link</a> is color-matched.</p>
     <progress class="progress mb-3" value="50" max="100">50%</progress>
-    <div class="btn-toolbar">
+    <div class="toolbar">
       <div class="btn-group">
         <button type="button" class="btn btn-color">Colored</button>
         <button type="button" class="btn btn-hover">On hover</button>
@@ -88,7 +88,7 @@ As a result of the use of CSS variable to style the colors, any element that res
   <div class="alert-message">
     <p>Look at this alert message! <a href="#">Link</a> is color-matched.</p>
     <progress class="progress mb-3" value="50" max="100">50%</progress>
-    <div class="btn-toolbar">
+    <div class="toolbar">
       <div class="btn-group">
         <button type="button" class="btn btn-color">Colored</button>
         <button type="button" class="btn btn-hover">On hover</button>

--- a/hugo/content/components/button-group.md
+++ b/hugo/content/components/button-group.md
@@ -43,21 +43,3 @@ While setting the individual button sizes is supported, you can also set the but
   <button type="button" class="btn btn-default">Group</button>
 </div>
 {{</example>}}
-
-## Toolbar
-You can combine multiple groups into a `btn-toolbar`. You can a also include a `btn` as a direct child.
-
-{{<example>}}
-<div class="btn-toolbar" role="toolbar">
-  <div class="btn-group" role="group">
-    <button type="button" class="btn btn-default">Button</button>
-    <button type="button" class="btn btn-default">Groups</button>
-    <button type="button" class="btn btn-default">In</button>
-  </div>
-  <div class="btn-group" role="group">
-    <button type="button" class="btn btn-default">A</button>
-    <button type="button" class="btn btn-default">Toolbar</button>
-  </div>
-  <button type="button" class="btn btn-danger">Single</button>
-</div>
-{{</example>}}

--- a/hugo/content/components/toolbar.md
+++ b/hugo/content/components/toolbar.md
@@ -4,7 +4,7 @@ description: Combine various actions in a single bar.
 section: components
 ---
 
-## Toolbar
+## Buttons
 You can combine multiple `btn-groups` into a `toolbar`. You can a also include a `btn` as a direct child, as any other component.
 
 {{<example>}}
@@ -19,5 +19,22 @@ You can combine multiple `btn-groups` into a `toolbar`. You can a also include a
     <button type="button" class="btn btn-default">Toolbar</button>
   </div>
   <button type="button" class="btn btn-danger">Single</button>
+</div>
+{{</example>}}
+
+## Inputs
+You can insert other elements into a toolbar too, like inputs and input groups.
+
+{{<example class="grid grid-1">}}
+<div class="toolbar" role="toolbar">
+  <input type="search" class="input" placeholder="Search" />
+  <button type="button" class="btn btn-primary">Search</button>
+</div>
+<div class="toolbar" role="toolbar">
+  <div class="input-group">
+    <span class="input-addon" id="prefix-addon">Prefix</span>
+    <input type="text" class="input" placeholder="Prefixed" aria-label="Prefixed" aria-describedby="prefix-addon">
+  </div>
+  <button type="button" class="btn btn-primary">Search</button>
 </div>
 {{</example>}}

--- a/hugo/content/components/toolbar.md
+++ b/hugo/content/components/toolbar.md
@@ -1,0 +1,23 @@
+---
+title: Toolbar
+description: Combine various actions in a single bar.
+section: components
+---
+
+## Toolbar
+You can combine multiple `btn-groups` into a `toolbar`. You can a also include a `btn` as a direct child, as any other component.
+
+{{<example>}}
+<div class="toolbar" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Button</button>
+    <button type="button" class="btn btn-default">Groups</button>
+    <button type="button" class="btn btn-default">In</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">A</button>
+    <button type="button" class="btn btn-default">Toolbar</button>
+  </div>
+  <button type="button" class="btn btn-danger">Single</button>
+</div>
+{{</example>}}

--- a/hugo/content/components/toolbar.md
+++ b/hugo/content/components/toolbar.md
@@ -24,6 +24,20 @@ You can combine multiple `btn-groups` into a `toolbar`. You can a also include a
 </div>
 {{</example>}}
 
+## Text
+You can also insert text into a toolbar. Text won't have any margin applied by default.
+
+{{<example>}}
+<div class="toolbar" role="toolbar">
+  <p class="fs-h5">Toolbar</p>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+{{</example>}}
+
 ## Inputs
 You can insert other elements into a toolbar too, like inputs and input groups.
 
@@ -101,6 +115,9 @@ Since a toolbar is an advanced flex component, you can use flex classes to align
   <button type="button" class="btn btn-danger">Delete</button>
 </div>
 <div class="toolbar" role="toolbar">
+  <p class="fs-h5">Toolbar</p>
+  <button type="button" class="btn btn-default">Edit</button>
+  <div class="flex-grow-1"></div>
   <div class="btn-group" role="group">
     <button type="button" class="btn btn-default">Bold</button>
     <button type="button" class="btn btn-default">Italic</button>
@@ -109,7 +126,6 @@ Since a toolbar is an advanced flex component, you can use flex classes to align
     <button type="button" class="btn btn-default">Align</button>
     <button type="button" class="btn btn-default">None</button>
   </div>
-  <div class="flex-grow-1"></div>
   <button type="button" class="btn btn-danger">Delete</button>
 </div>
 {{</example>}}

--- a/hugo/content/components/toolbar.md
+++ b/hugo/content/components/toolbar.md
@@ -4,6 +4,8 @@ description: Combine various actions in a single bar.
 section: components
 ---
 
+The toolbar applies some default markup to make elements appear properly on a single line as you'd expect.
+
 ## Buttons
 You can combine multiple `btn-groups` into a `toolbar`. You can a also include a `btn` as a direct child, as any other component.
 
@@ -36,5 +38,78 @@ You can insert other elements into a toolbar too, like inputs and input groups.
     <input type="text" class="input" placeholder="Prefixed" aria-label="Prefixed" aria-describedby="prefix-addon">
   </div>
   <button type="button" class="btn btn-primary">Search</button>
+</div>
+{{</example>}}
+
+## Align to end
+Since a toolbar is an advanced flex component, you can use flex classes to align content.
+
+{{<example class="grid grid-1">}}
+<div class="toolbar justify-content-start" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">Start</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+<div class="toolbar justify-content-center" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">Center</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+<div class="toolbar justify-content-end" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">End</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+<div class="toolbar justify-content-between" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">Between</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+<div class="toolbar justify-content-around" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">Around</button>
+  </div>
+  <button type="button" class="btn btn-danger">Delete</button>
+</div>
+<div class="toolbar" role="toolbar">
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Bold</button>
+    <button type="button" class="btn btn-default">Italic</button>
+  </div>
+  <div class="btn-group" role="group">
+    <button type="button" class="btn btn-default">Align</button>
+    <button type="button" class="btn btn-default">None</button>
+  </div>
+  <div class="flex-grow-1"></div>
+  <button type="button" class="btn btn-danger">Delete</button>
 </div>
 {{</example>}}

--- a/hugo/data/docs.yml
+++ b/hugo/data/docs.yml
@@ -43,6 +43,7 @@
     - title: Pivot
     - title: Placeholder
     - title: Progress
+    - title: Toolbar
 
 - title: Advanced
   pages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_button-groups.scss
+++ b/scss/_button-groups.scss
@@ -33,14 +33,3 @@
     @extend .btn-lg;
   }
 }
-
-.btn-toolbar {
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-
-  > .btn:not(:last-child),
-  > .btn-group:not(:last-child) {
-    margin-right: .5rem;
-  }
-}

--- a/scss/_toolbar.scss
+++ b/scss/_toolbar.scss
@@ -1,0 +1,10 @@
+.toolbar {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+
+  > .btn:not(:last-child),
+  > .btn-group:not(:last-child) {
+    margin-right: .5rem;
+  }
+}

--- a/scss/_toolbar.scss
+++ b/scss/_toolbar.scss
@@ -16,4 +16,21 @@
   > .input-group {
     width: initial;
   }
+
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6,
+  > .h1,
+  > .h2,
+  > .h3,
+  > .h4,
+  > .h5,
+  > .h6,
+  > p {
+    margin: 0;
+    align-self: center;
+  }
 }

--- a/scss/_toolbar.scss
+++ b/scss/_toolbar.scss
@@ -3,8 +3,17 @@
   justify-content: flex-start;
   flex-wrap: wrap;
 
-  > .btn:not(:last-child),
-  > .btn-group:not(:last-child) {
+  > :not(:last-child) {
     margin-right: .5rem;
+  }
+
+  > .input,
+  > .input-group > .input {
+    display: inline-block;
+    width: initial;
+  }
+
+  > .input-group {
+    width: initial;
   }
 }

--- a/scss/mellow.scss
+++ b/scss/mellow.scss
@@ -48,6 +48,7 @@
 @import "pivot";
 @import "placeholder";
 @import "progress";
+@import "toolbar";
 
 @import "pwa";
 


### PR DESCRIPTION
Mellow CSS 0.11 is a feature update that introduces a revamped `toolbar` component.

## Changes
- [x] **Toolbar revamp**: introduces a revamped toolbar with support for more content types.
  - [x] ee2bfa7 Renames `btn-toolbar` to `toolbar`.
  - [x] d5dfe1f The `toolbar` class now supports `input` and `input-group` as well as improved support for other elements.
  - [x] d517721 Adds support for text elements in `toolbar`.