### PR TITLE
Mellow CSS 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sippy-platform/mellow-css",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/cli": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/mellow-css",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The Mellow Design System.",
   "main": "dist/js/mellow.js",
   "style": "dist/css/mellow.css",

--- a/scss/_button-close.scss
+++ b/scss/_button-close.scss
@@ -27,7 +27,7 @@
   }
 
   &:hover {
-    background-color: rgba($dark, .1);
+    background-color: var(--system-10);
     border-color: var(--accent-800);
   }
 }

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -40,7 +40,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacer * .75 $spacer * .75 0;
+  padding: $spacer * .75 $spacer * 1 0;
 
   .dialog-title {
     margin: 0;
@@ -48,7 +48,7 @@
 }
 
 .dialog-body {
-  padding: $spacer * .75;
+  padding: $spacer * 1;
 
   :last-child {
     margin-bottom: 0;
@@ -59,6 +59,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: $spacer * .75;
+  padding: $spacer * 1;
   border-top: $border-width solid $border-color;
 }

--- a/scss/_dialog.scss
+++ b/scss/_dialog.scss
@@ -56,9 +56,6 @@
 }
 
 .dialog-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: $spacer * 1;
   border-top: $border-width solid $border-color;
 }

--- a/scss/_dropdown.scss
+++ b/scss/_dropdown.scss
@@ -75,6 +75,8 @@
   border-radius: $border-radius-sm;
   outline: none;
   color: $body-text;
+  width: 100%;
+  box-sizing: border-box;
 
   &:not(:first-child) {
     margin-top: .125rem;

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -46,6 +46,9 @@ body {
   --light: initial;
   --dark: ;
 
+  // System colors
+  --system-10: #{ light-dark(rgba($dark, .1), rgba($light, .1)) };
+
   // Colors
   @each $name, $color in $colors {
     --#{$name}-50: #{ light-dark(tint($color, 96%), shade($color, 80%)) };


### PR DESCRIPTION
Mellow CSS 0.11.1 is a minor release to fix a set of issues and make other minor adjustments.

## Changes
- 4234a91 Improve the spacing within the dialog classes to appear less awkward.

## Fixes
- 464b949 Fixes the `btn-close` class not providing proper support for the dark theme.
- 816c2a6 Removes the flex behavior from the `dialog-footer` to keep it from messing with internal toolbars.
- 36bf503 Fixes a bug where `dropdown-item` would take up the full width if it was a button.